### PR TITLE
Improve run.sh clarity

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ kong migrations bootstrap
 kong start --v
 
 # Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.
-while true;do
+while true; do
   sleep 10
   if ! pgrep --full "nginx: master process" > /dev/null; then
     echo "Main Nginx process crashed"

--- a/run.sh
+++ b/run.sh
@@ -32,7 +32,6 @@ while true;do
   sleep 10
   if ! pgrep --full "nginx: master process" > /dev/null; then
     echo "Main Nginx process crashed"
-    ps aux
     exit 1
   fi
 done

--- a/run.sh
+++ b/run.sh
@@ -27,13 +27,12 @@ export KONG_LUA_PACKAGE_CPATH=$LUA_CPATH
 kong migrations bootstrap
 kong start --vv
 
-# Keep this process alive
+# Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.
 while true;do
-	sleep 10
-	nginx_count=`ps aux | grep maste[r] | wc -l`
-	if [ "$nginx_count" != "1" ];then
-		echo "Some process crashed"
-		ps aux
-		exit 1
-	fi
+  sleep 10
+  if ! pgrep --full "nginx: master process" > /dev/null; then
+    echo "Main Nginx process crashed"
+    ps aux
+    exit 1
+  fi
 done

--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ export KONG_LUA_PACKAGE_CPATH=$LUA_CPATH
 
 # Start kong
 kong migrations bootstrap
-kong start --vv
+kong start --v
 
 # Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.
 while true;do

--- a/run.sh
+++ b/run.sh
@@ -23,8 +23,9 @@ export KONG_PG_PASSWORD=`echo $VCAP_SERVICES | jq -r '.["'$SERVICE'"][0].credent
 export KONG_LUA_PACKAGE_PATH=$LUA_PATH
 export KONG_LUA_PACKAGE_CPATH=$LUA_CPATH
 
-# Start kong
-kong migrations bootstrap
+# Start kong. Only use 'kong migrations' command if using Kong with DB mode enabled. See DB-less info
+# here https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/
+kong migrations bootstrap 
 kong start --v
 
 # Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.


### PR DESCRIPTION
## Changes proposed in this pull request:

- Improved logic for locating Nginx master process
- Improved comments for new users of this repo/template
- Switch 'kong start' verbosity level to a more reasonable default

## Security considerations

None to note. I have tested these changes in my own cloud.gov Kong deployment (we used this repo as our template).
