### PR TITLE
clarify run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -29,10 +29,8 @@ kong migrations bootstrap
 kong start --v
 
 # Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.
-while true; do
+while kong health > /dev/null; do
   sleep 10
-  if ! pgrep --full "nginx: master process" > /dev/null; then
-    echo "Main Nginx process crashed"
-    exit 1
-  fi
 done
+
+exit 1


### PR DESCRIPTION
It turns out, Kong knows how to monitor its own health and has a CLI
command to do so. This abstracts away the details of how, and lets the
script focus on the more important issue "is Kong healthy?".

https://docs.konghq.com/gateway-oss/latest/cli/#kong-health

## Changes proposed in this pull request:

- Remove custom health-check logic for kong and instead rely on the built-in `kong health` command

## Security considerations

None
