### PR TITLE
Turn off the Kong Nginx Daemon

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,16 +23,10 @@ export KONG_PG_PASSWORD=`echo $VCAP_SERVICES | jq -r '.["'$SERVICE'"][0].credent
 export KONG_LUA_PACKAGE_PATH=$LUA_PATH
 export KONG_LUA_PACKAGE_CPATH=$LUA_CPATH
 
+# Ensure the kong process runs in the foreground.
+export KONG_NGINX_DAEMON=off
+
 # Start kong. Only use 'kong migrations' command if using Kong with DB mode enabled. See DB-less info
 # here https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/
 kong migrations bootstrap 
 kong start --v
-
-# Keep this shell process alive. If it exits, it will cause cloudfoundry to try to restart the instance.
-while true; do
-  sleep 10
-  if ! pgrep --full "nginx: master process" > /dev/null; then
-    echo "Main Nginx process crashed"
-    exit 1
-  fi
-done


### PR DESCRIPTION
The kong nginx daemon is 'on' by default, which causes Kong to run as a
background daemon instead of a foreground process. This is contrary to
how Cloud Foundry expects applications to run. The default CloudFoundry
Nginx Buildpack configuration sets its daemon off for this reason. See
https://github.com/cloudfoundry/nginx-buildpack/blob/master/fixtures/mainline/nginx.conf

With the daemon off, Kong behaves very similarly to the default Nginx
buildpack (running in the foreground, exiting on a crash, and responding
gracefully to platform SIG* signals). Due to this, it is no longer necessary
to monitor for Nginx processes within the `run.sh` script, and the run script
will automatically be kept alive until Kong exits.

## Changes proposed in this pull request:

- Set the `nginx_daemon` setting in Kong to 'off'

## Security considerations

None. Kong behaves well in this configuration and it is even more in-line with default
cloud-foundry buildpacks now.
