### PR TITLE
Correct the apt.yml repo URL

### DIFF
--- a/apt.yml
+++ b/apt.yml
@@ -1,7 +1,5 @@
 ---
-keys:
-- https://bintray.com/user/downloadSubjectPublicKey?username=bintray
 repos:
-- deb https://kong.bintray.com/kong-deb bionic main
+  - deb [trusted=yes] https://download.konghq.com/gateway-2.x-ubuntu-bionic/ default all
 packages:
-- kong
+  - kong


### PR DESCRIPTION
The previous install method using bintray is no longer available after
its shutdown in May (see
https://discuss.konghq.com/t/docs-bintray-service-shuts-down-in-may/8033).
The new recommended repository install method uses download.konghq.com.
See https://docs.konghq.com/install/ubuntu/ for detail.
